### PR TITLE
add PodDisruptionBudget for each RedisCluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,10 @@ jobs:
     - docker images
     - kubectl get pods --all-namespaces
     - helm install --wait --version $TAG -n end2end-test --set image.pullPolicy=IfNotPresent --set image.tag=$TAG chart/redis-operator
+    - kubectl logs -f $(kubectl get pod -l app=redis-operator --output=jsonpath={.items[0].metadata.name}) > /tmp/tmp.operator.logs &
     - cd ./test/e2e && go test -c && ./e2e.test --kubeconfig=$HOME/.kube/config --image-tag=$TAG --ginkgo.slowSpecThreshold 200
     - helm delete end2end-test
+    - cat /tmp/tmp.operator.logs
   - stage: release
     name: release
     script:

--- a/chart/redis-operator/templates/rbac.yaml
+++ b/chart/redis-operator/templates/rbac.yaml
@@ -25,6 +25,10 @@ items:
     resources:
     - namespaces
     verbs: ["list"]
+  - apiGroups: ["policy"]
+    resources:
+    - poddisruptionbudgets
+    verbs: ["*"]
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,12 +2,11 @@
 
 ![logo](imgs/logo.png)
 
-### Build Status
+## Build Status
+
 [![Build Status](https://travis-ci.org/AmadeusITGroup/Redis-Operator.svg?branch=master)](https://travis-ci.org/AmadeusITGroup/Redis-Operator)
 [![Go Report Card](https://goreportcard.com/badge/github.com/amadeusitgroup/redis-operator)](https://goreportcard.com/report/github.com/amadeusitgroup/redis-operator)
 [![codecov](https://codecov.io/gh/amadeusitgroup/redis-operator/branch/master/graph/badge.svg)](https://codecov.io/gh/amadeusitgroup/redis-operator)
-
-
 
 ## Project status: alpha
 
@@ -17,7 +16,7 @@ The aim of this project is to ease the deployment and operations of a [Redis-clu
 
 ## Overview
 
-The Redis-cluster will be deployed thanks to a unique deployment. Each node of the Redis-cluster is running in its own Pod; At startup, each node has no active role (not slave nor master with slot), it just joins the cluster as a master without slot. See representation in the schema below 
+The Redis-cluster will be deployed thanks to a unique deployment. Each node of the Redis-cluster is running in its own Pod; At startup, each node has no active role (not slave nor master with slot), it just joins the cluster as a master without slot. See representation in the schema below.
 
 ![Initial state](imgs/overview_1.png)
 
@@ -53,7 +52,7 @@ You can found in the `charts` folder two helm charts:
 - `redis-operator`: used to deploy the `redis-operator` into your kubernetes cluster.
 - `redis-cluster`: used to create a "Redis Cluster" instance thanks to the `redis-operator`.
 
-#### Instanciate the `redis-operator`:
+#### Instanciate the `redis-operator`
 
 ```console
 helm install --name op charts/redis-operator

--- a/pkg/controller/poddisruptionbudget_control.go
+++ b/pkg/controller/poddisruptionbudget_control.go
@@ -1,0 +1,92 @@
+package controller
+
+import (
+	"fmt"
+
+	policyv1 "k8s.io/api/policy/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
+
+	rapi "github.com/amadeusitgroup/redis-operator/pkg/api/redis/v1"
+	"github.com/amadeusitgroup/redis-operator/pkg/controller/pod"
+)
+
+// PodDisruptionBudgetsControlInterface inferface for the PodDisruptionBudgetsControl
+type PodDisruptionBudgetsControlInterface interface {
+	// CreateRedisClusterPodDisruptionBudget used to create the Kubernetes PodDisruptionBudget needed to access the Redis Cluster
+	CreateRedisClusterPodDisruptionBudget(redisCluster *rapi.RedisCluster) (*policyv1.PodDisruptionBudget, error)
+	// DeleteRedisClusterPodDisruptionBudget used to delete the Kubernetes PodDisruptionBudget linked to the Redis Cluster
+	DeleteRedisClusterPodDisruptionBudget(redisCluster *rapi.RedisCluster) error
+	// GetRedisClusterPodDisruptionBudget used to retrieve the Kubernetes PodDisruptionBudget associated to the RedisCluster
+	GetRedisClusterPodDisruptionBudget(redisCluster *rapi.RedisCluster) (*policyv1.PodDisruptionBudget, error)
+}
+
+// PodDisruptionBudgetsControl contains all information for managing Kube PodDisruptionBudgets
+type PodDisruptionBudgetsControl struct {
+	KubeClient clientset.Interface
+	Recorder   record.EventRecorder
+}
+
+// NewPodDisruptionBudgetsControl builds and returns new PodDisruptionBudgetsControl instance
+func NewPodDisruptionBudgetsControl(client clientset.Interface, rec record.EventRecorder) *PodDisruptionBudgetsControl {
+	ctrl := &PodDisruptionBudgetsControl{
+		KubeClient: client,
+		Recorder:   rec,
+	}
+
+	return ctrl
+}
+
+// GetRedisClusterPodDisruptionBudget used to retrieve the Kubernetes PodDisruptionBudget associated to the RedisCluster
+func (s *PodDisruptionBudgetsControl) GetRedisClusterPodDisruptionBudget(redisCluster *rapi.RedisCluster) (*policyv1.PodDisruptionBudget, error) {
+	PodDisruptionBudgetName := redisCluster.Name
+	pdb, err := s.KubeClient.PolicyV1beta1().PodDisruptionBudgets(redisCluster.Namespace).Get(PodDisruptionBudgetName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if pdb.Name != PodDisruptionBudgetName {
+		return nil, fmt.Errorf("Couldn't find PodDisruptionBudget named %s", PodDisruptionBudgetName)
+	}
+	return pdb, nil
+}
+
+// DeleteRedisClusterPodDisruptionBudget used to delete the Kubernetes PodDisruptionBudget linked to the Redis Cluster
+func (s *PodDisruptionBudgetsControl) DeleteRedisClusterPodDisruptionBudget(redisCluster *rapi.RedisCluster) error {
+	return s.KubeClient.PolicyV1beta1().PodDisruptionBudgets(redisCluster.Namespace).Delete(redisCluster.Name, nil)
+}
+
+// CreateRedisClusterPodDisruptionBudget used to create the Kubernetes PodDisruptionBudget needed to access the Redis Cluster
+func (s *PodDisruptionBudgetsControl) CreateRedisClusterPodDisruptionBudget(redisCluster *rapi.RedisCluster) (*policyv1.PodDisruptionBudget, error) {
+	PodDisruptionBudgetName := redisCluster.Name
+	desiredlabels, err := pod.GetLabelsSet(redisCluster)
+	if err != nil {
+		return nil, err
+
+	}
+
+	desiredAnnotations, err := pod.GetAnnotationsSet(redisCluster)
+	if err != nil {
+		return nil, err
+	}
+	maxUnavailable := intstr.FromInt(1)
+	labelSelector := metav1.LabelSelector{
+		MatchLabels: desiredlabels,
+	}
+	newPodDisruptionBudget := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:          desiredlabels,
+			Annotations:     desiredAnnotations,
+			Name:            PodDisruptionBudgetName,
+			OwnerReferences: []metav1.OwnerReference{pod.BuildOwnerReference(redisCluster)},
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			MaxUnavailable: &maxUnavailable,
+			Selector:       &labelSelector,
+		},
+	}
+	return s.KubeClient.PolicyV1beta1().PodDisruptionBudgets(redisCluster.Namespace).Create(newPodDisruptionBudget)
+}

--- a/pkg/controller/sanitycheck/clustersplit_test.go
+++ b/pkg/controller/sanitycheck/clustersplit_test.go
@@ -1,4 +1,5 @@
 // +build !race
+
 package sanitycheck
 
 import (

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -139,6 +139,12 @@ func (op *RedisOperator) configureHealth() {
 		}
 		return fmt.Errorf("Service cache not sync")
 	})
+	op.health.AddReadinessCheck("PodDiscruptionBudget_cache_sync", func() error {
+		if op.controller.PodDiscruptionBudgetSynced() {
+			return nil
+		}
+		return fmt.Errorf("PodDiscruptionBudget cache not sync")
+	})
 }
 
 func (op *RedisOperator) runHTTPServer(stop <-chan struct{}) error {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -18,7 +18,7 @@ type Framework struct {
 
 type frameworkContextType struct {
 	KubeConfigPath string
-	ImageTag  string
+	ImageTag       string
 }
 
 // FrameworkContext stores globally the framework context

--- a/test/e2e/framework/operator_util.go
+++ b/test/e2e/framework/operator_util.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/golang/glog"
 
-	. "github.com/onsi/gomega"
+	gomega "github.com/onsi/gomega"
 
 	"github.com/amadeusitgroup/redis-operator/pkg/api/redis"
 	rapi "github.com/amadeusitgroup/redis-operator/pkg/api/redis/v1"
@@ -109,17 +109,17 @@ func NewRedisCluster(name, namespace, tag string, nbMaster, replication int32) *
 // BuildAndSetClients builds and initilize rediscluster and kube client
 func BuildAndSetClients() (versioned.Interface, clientset.Interface) {
 	f, err := NewFramework()
-	Ω(err).ShouldNot(HaveOccurred())
-	Ω(f).ShouldNot(BeNil())
+	gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
+	gomega.Ω(f).ShouldNot(gomega.BeNil())
 
 	kubeClient, err := f.kubeClient()
-	Ω(err).ShouldNot(HaveOccurred())
-	Ω(kubeClient).ShouldNot(BeNil())
+	gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
+	gomega.Ω(kubeClient).ShouldNot(gomega.BeNil())
 	Logf("Check whether RedisCluster resource is registered...")
 
 	redisClient, err := f.redisOperatorClient()
-	Ω(err).ShouldNot(HaveOccurred())
-	Ω(redisClient).ShouldNot(BeNil())
+	gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
+	gomega.Ω(redisClient).ShouldNot(gomega.BeNil())
 	return redisClient, kubeClient
 }
 
@@ -305,6 +305,19 @@ func HOCreateRedisNodeServiceAccount(client clientset.Interface, rediscluster *r
 			if err != nil {
 				return err
 			}
+		}
+		return nil
+	}
+}
+
+// HOIsRedisClusterPodDisruptionBudgetCreated is an higher order func that returns the func that checks whether PodDisruptionBudget associated to the
+// the RedisCluster have been created properly.
+func HOIsRedisClusterPodDisruptionBudgetCreated(client clientset.Interface, rediscluster *rapi.RedisCluster) func() error {
+	return func() error {
+		_, err := client.PolicyV1beta1().PodDisruptionBudgets(rediscluster.Namespace).Get(rediscluster.Name, metav1.GetOptions{})
+		if err != nil {
+			Logf("Cannot get PodDisruptionBudget associated to the rediscluster:%s/%s, err:%v", rediscluster.Namespace, rediscluster.Name, err)
+			return err
 		}
 		return nil
 	}

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -43,7 +43,10 @@ var _ = Describe("RedisCluster CRUD", func() {
 
 		Eventually(framework.HOCreateRedisCluster(redisClient, rediscluster, clusterNs), "5s", "1s").ShouldNot(HaveOccurred())
 
+		Eventually(framework.HOIsRedisClusterPodDisruptionBudgetCreated(kubeClient, rediscluster), "5s", "1s").ShouldNot(HaveOccurred())
+
 		Eventually(framework.HOIsRedisClusterStarted(redisClient, rediscluster, clusterNs), "5m", "5s").ShouldNot(HaveOccurred())
+
 	})
 
 	Context("when the Redis Cluster is created properly", func() {


### PR DESCRIPTION
Fixes: #9

In order to protect the RedisCluster, it is important to limit the
number of Pod that can be delete. The operator now create a
PodDisruptionBudget for each RedisCluster instance corresponding to the
service LabelSelector and limit to only one Pod deletion at the time.