### PR TITLE
New --config-file option in redis-node + configmap support in helm chart

### DIFF
--- a/chart/redis-cluster/templates/RedisCluster.yml
+++ b/chart/redis-cluster/templates/RedisCluster.yml
@@ -2,6 +2,8 @@ apiVersion: "redisoperator.k8s.io/v1alpha1"
 kind: RedisCluster
 metadata:
   name: {{ template "cluster-name" . }}
+  labels:
+    app: {{ template "name" . }}
 spec:
   numberOfMaster: {{ .Values.numberOfMaster }}
   replicationFactor: {{ .Values.replicationFactor }}
@@ -15,10 +17,18 @@ spec:
       volumes:
         - name: data
           emptyDir: {}
+        - name: conf
+          emptyDir: {}
+{{- if .Values.redis.configuration.file }}
+        - name: extra-conf
+          configMap:
+            name: {{ template "cluster-name" . }}
+{{- end }}
       containers:
         - name: redis-node
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           args: ["--v={{ .Values.log.level }}", 
+            "--c=/redis-conf/redis.conf",
             "--logtostderr=true", 
             "--alsologtostderr=true",
             "--rs={{ template "service-name" . }}", 
@@ -31,6 +41,9 @@ spec:
 {{- if .Values.maxMemoryPolicy }}
              "--max-memory-policy={{ .Values.maxMemoryPolicy }}",
 {{- end }}
+{{- if .Values.redis.configuration.file }}
+            "--config-file=/redis-extra-conf/redis.conf",
+{{- end }}
             "--cluster-node-timeout=2000"]
           imagePullPolicy: IfNotPresent
           ports:
@@ -41,6 +54,12 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /redis-data
+            - name: conf
+              mountPath: /redis-conf
+{{- if .Values.redis.configuration.file }}
+            - name: extra-conf
+              mountPath: /redis-extra-conf
+{{- end }}
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/chart/redis-cluster/templates/configmap.yaml
+++ b/chart/redis-cluster/templates/configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.redis.configuration.file }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "cluster-name" . }}
+  labels:
+    app: {{ template "name" . }}
+data:
+  redis.conf: |-
+{{ (.Files.Get .Values.redis.configuration.file) | indent 4 }}
+    
+{{- end }}

--- a/chart/redis-cluster/values.yaml
+++ b/chart/redis-cluster/values.yaml
@@ -27,3 +27,12 @@ resources: {}
   #  cpu: 1
   #  memory: 1024Mi
 maxMemoryPolicy: noeviction
+# list of additional redis configuration file that need to be included in the generated redis-server
+# configuration file. File can be accessible to the process by rebuilding the "redis-node" docker image
+# with the specific file, or by add a ConfigMap volume to the Pod.
+redis:
+  configuration:
+    # you can provide the path of a redis configuration file that will be added in a configMap and included
+    # in the redis-server configuration in each redis-cluster node.
+    # the file must be local of the helm chart (in the chart folder).
+    file: ""

--- a/pkg/config/redis.go
+++ b/pkg/config/redis.go
@@ -18,25 +18,44 @@ const (
 	// RedisRenameCommandsDefaultFile default file name containing rename commands
 	RedisRenameCommandsDefaultFile = ""
 	// RedisConfigFileDefault default config file path
-	RedisConfigFileDefault = "/redis-server/redis.conf"
+	RedisConfigFileDefault = "/redis-conf/redis.conf"
+	// RedisServerBinDefault default binary name
+	RedisServerBinDefault = "redis-server"
+	// RedisServerPortDefault default redis port
+	RedisServerPortDefault = "6379"
+	// RedisMaxMemoryDefault default redis max memory
+	RedisMaxMemoryDefault = 0
+	// RedisMaxMemoryPolicyDefault default redis max memory evition policy
+	RedisMaxMemoryPolicyDefault = "noeviction"
 )
 
 // Redis used to store all Redis configuration information
 type Redis struct {
 	DialTimeout        int
 	ClusterNodeTimeout int
-	ConfigFile         string
+	ConfigFileName     string
 	renameCommandsPath string
 	renameCommandsFile string
+	HTTPServerAddr     string
+	ServerBin          string
+	ServerPort         string
+	MaxMemory          uint32
+	MaxMemoryPolicy    string
+	ConfigFiles        []string
 }
 
 // AddFlags use to add the Redis Config flags to the command line
 func (r *Redis) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&r.DialTimeout, "rdt", DefaultRedisTimeout, "redis dial timeout (ms)")
 	fs.IntVar(&r.ClusterNodeTimeout, "cluster-node-timeout", DefaultClusterNodeTimeout, "redis node timeout (ms)")
-	fs.StringVar(&r.ConfigFile, "c", RedisConfigFileDefault, "redis config file path")
+	fs.StringVar(&r.ConfigFileName, "c", RedisConfigFileDefault, "redis config file path")
 	fs.StringVar(&r.renameCommandsPath, "rename-command-path", RedisRenameCommandsDefaultPath, "Path to the folder where rename-commands option for redis are available")
 	fs.StringVar(&r.renameCommandsFile, "rename-command-file", RedisRenameCommandsDefaultFile, "Name of the file where rename-commands option for redis are available, disabled if empty")
+	fs.Uint32Var(&r.MaxMemory, "max-memory", RedisMaxMemoryDefault, "redis max memory")
+	fs.StringVar(&r.MaxMemoryPolicy, "max-memory-policy", RedisMaxMemoryPolicyDefault, "redis max memory evition policy")
+	fs.StringVar(&r.ServerBin, "bin", RedisServerBinDefault, "redis server binary file name")
+	fs.StringVar(&r.ServerPort, "port", RedisServerPortDefault, "redis server listen port")
+	fs.StringArrayVar(&r.ConfigFiles, "config-file", []string{}, "Location of redis configuration file that will be include in the ")
 
 }
 
@@ -55,5 +74,9 @@ func (r Redis) String() string {
 	output += fmt.Sprintln("- DialTimeout:", r.DialTimeout)
 	output += fmt.Sprintln("- ClusterNodeTimeout:", r.ClusterNodeTimeout)
 	output += fmt.Sprintln("- Rename commands:", r.GetRenameCommandsFile())
+	output += fmt.Sprintln("- max-memory:", r.MaxMemory)
+	output += fmt.Sprintln("- max-memory-policy:", r.MaxMemoryPolicy)
+	output += fmt.Sprintln("- server-bin:", r.ServerBin)
+	output += fmt.Sprintln("- server-port:", r.ServerPort)
 	return output
 }

--- a/pkg/redisnode/config.go
+++ b/pkg/redisnode/config.go
@@ -12,31 +12,19 @@ const (
 	RedisStartWaitDefault = 10 * time.Second
 	// RedisStartDelayDefault default start delay duration (sec)
 	RedisStartDelayDefault = 10 * time.Second
-	// RedisServerBinDefault default binary name
-	RedisServerBinDefault = "redis-server"
-	// RedisServerPortDefault default redis port
-	RedisServerPortDefault = "6379"
 	// HTTPServerAddrDefault default http server address
 	HTTPServerAddrDefault = "0.0.0.0:8080"
-	// RedisMaxMemoryDefault default redis max memory
-	RedisMaxMemoryDefault = 0
-	// RedisMaxMemoryPolicyDefault default redis max memory evition policy
-	RedisMaxMemoryPolicyDefault = "noeviction"
 )
 
 // Config contains configuration for redis-operator
 type Config struct {
-	KubeConfigFile       string
-	Master               string
-	Redis                config.Redis
-	Cluster              config.Cluster
-	RedisServerBin       string
-	RedisServerPort      string
-	RedisStartWait       time.Duration
-	RedisStartDelay      time.Duration
-	HTTPServerAddr       string
-	RedisMaxMemory       uint32
-	RedisMaxMemoryPolicy string
+	KubeConfigFile  string
+	Master          string
+	Redis           config.Redis
+	Cluster         config.Cluster
+	RedisStartWait  time.Duration
+	RedisStartDelay time.Duration
+	HTTPServerAddr  string
 }
 
 // NewRedisNodeConfig builds and returns a redis-operator Config
@@ -51,12 +39,6 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.Master, "master", c.Master, "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	fs.DurationVar(&c.RedisStartWait, "t", RedisStartWaitDefault, "Max time waiting for redis to start")
 	fs.DurationVar(&c.RedisStartDelay, "d", RedisStartDelayDefault, "delay before that the redis-server is started")
-
-	fs.StringVar(&c.RedisServerBin, "bin", RedisServerBinDefault, "redis server binary file name")
-	fs.StringVar(&c.RedisServerPort, "port", RedisServerPortDefault, "redis server listen port")
-	fs.Uint32Var(&c.RedisMaxMemory, "max-memory", RedisMaxMemoryDefault, "redis max memory")
-	fs.StringVar(&c.RedisMaxMemoryPolicy, "max-memory-policy", RedisMaxMemoryPolicyDefault, "redis max memory evition policy")
-
 	fs.StringVar(&c.HTTPServerAddr, "http-addr", HTTPServerAddrDefault, "the http server listen address")
 
 	c.Redis.AddFlags(fs)

--- a/pkg/redisnode/redisnode.go
+++ b/pkg/redisnode/redisnode.go
@@ -198,7 +198,7 @@ func (r *RedisNode) isClusterInitialization(currentIP string) ([]string, bool) {
 		glog.Info("Redis Node list empty")
 	}
 
-	if len(nodesAddr) == 1 && nodesAddr[0] == net.JoinHostPort(currentIP, r.config.RedisServerPort) {
+	if len(nodesAddr) == 1 && nodesAddr[0] == net.JoinHostPort(currentIP, r.config.Redis.ServerPort) {
 		// Init Master cluster
 		initCluster = true
 	}
@@ -231,7 +231,7 @@ func (r *RedisNode) configureHealth() error {
 		glog.Errorf("unable to get my IP, err:%v", err)
 		return err
 	}
-	addr := net.JoinHostPort(ip, r.config.RedisServerPort)
+	addr := net.JoinHostPort(ip, r.config.Redis.ServerPort)
 
 	health := healthcheck.NewHandler()
 	health.AddReadinessCheck("Check redis-node readiness", func() error {
@@ -303,7 +303,7 @@ func (r *RedisNode) runHTTPServer(stop <-chan struct{}) error {
 
 // WrapRedis start a redis server in a sub process
 func WrapRedis(c *Config, ch chan error) {
-	cmd := exec.Command(c.RedisServerBin, c.Redis.ConfigFile)
+	cmd := exec.Command(c.Redis.ServerBin, c.Redis.ConfigFileName)
 	cmd.Stdout = utils.NewLogWriter(glog.Info)
 	cmd.Stderr = utils.NewLogWriter(glog.Error)
 

--- a/pkg/redisnode/redisnode_test.go
+++ b/pkg/redisnode/redisnode_test.go
@@ -34,8 +34,8 @@ func TestTestAndWaitConnection(t *testing.T) {
 func TestIsClusterInitialization(t *testing.T) {
 	currentIP := "1.2.3.4"
 	conf := Config{
-		RedisServerPort: "1234",
-		Cluster:         config.Cluster{Namespace: "default", NodeService: "redis-service"},
+		Redis:   config.Redis{ServerPort: "1234"},
+		Cluster: config.Cluster{Namespace: "default", NodeService: "redis-service"},
 	}
 
 	testCases := []struct {
@@ -86,9 +86,8 @@ func TestRedisInitializationAttach(t *testing.T) {
 	defer os.Remove(tmpfile.Name()) // clean up
 
 	c := &Config{
-		RedisServerPort: "1234",
-		Redis:           config.Redis{ConfigFile: tmpfile.Name()},
-		Cluster:         config.Cluster{Namespace: "default", NodeService: "redis-service"},
+		Redis:   config.Redis{ServerPort: "1234", ConfigFileName: tmpfile.Name()},
+		Cluster: config.Cluster{Namespace: "default", NodeService: "redis-service"},
 	}
 
 	// other ips registered, will attach to them

--- a/test/e2e/framework/operator_util.go
+++ b/test/e2e/framework/operator_util.go
@@ -46,6 +46,7 @@ func NewRedisCluster(name, namespace, tag string, nbMaster, replication int32) *
 					ServiceAccountName: "redis-node",
 					Volumes: []v1.Volume{
 						{Name: "data"},
+						{Name: "conf"},
 					},
 					Containers: []v1.Container{
 						{
@@ -68,6 +69,7 @@ func NewRedisCluster(name, namespace, tag string, nbMaster, replication int32) *
 							},
 							VolumeMounts: []v1.VolumeMount{
 								{Name: "data", MountPath: "/redis-data"},
+								{Name: "conf", MountPath: "/redis-conf"},
 							},
 							Env: []v1.EnvVar{
 								{Name: "POD_NAMESPACE", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}},


### PR DESCRIPTION
Fixes: #19 

Add new `redis-node` option for including redis configuration files in the generated redis-conf file.

Files will be added at the end of the default file. like this those additional configuration files will be able to overwrite default values or value already set.