### PR TITLE
New travis stage for docker push on master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,12 @@ jobs:
       - docker login -u "$DOCKER_USERNAME" p "$DOCKER_PASSWORD"
       - curl -sL https://git.io/goreleaser | bash
     deploy:
+    - provider: script
+      script:
+      - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+      - make TAG=master push
+      on:
+        branch: master
     - provider: releases
       api_key:
         secure: $GITHUB_TOKEN

--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ helm install --name mycluster charts/redis-cluster --set numberOfMaster=3 --set 
 ...
 ```
 
+> **! Warning !**, if you want to use the docker images corresponding  to the level of code present in the "master" branch. you need to set the image tag when you instanciate the Redis-Cluster chart and the Redis-Operator chart. The "latest" tag is corresponding to the last validated release.
+
+```console
+helm install --name mycluster charts/redis-cluster --set image.tag=master --set numberOfMaster=3 --set replicationFactor=1
+...
+```
+
 #### Install the kubctl redis-cluster plugin
 
 docs available [here](docs/kubectl-plugin.md).


### PR DESCRIPTION
Fixes: #24

after each merge on the "master" branch, travis will build and push the docker
images with the tag: "master"