### PR TITLE
fix SIGSEGV in checkIfPodNameExistAndIsReused function

### DIFF
--- a/pkg/controller/sanitycheck/untrustednodes.go
+++ b/pkg/controller/sanitycheck/untrustednodes.go
@@ -76,6 +76,9 @@ func listUntrustedNodes(infos *redis.ClusterInfos) map[string]*redis.Node {
 }
 
 func checkIfPodNameExistAndIsReused(node *redis.Node, podlist []*kapi.Pod) (exist bool, reused bool) {
+	if node.Pod == nil {
+		return exist, reused
+	}
 	for _, currentPod := range podlist {
 		if currentPod.Name == node.Pod.Name {
 			exist = true


### PR DESCRIPTION
In some specific case a "redis.Node"doesn't have its associated Pod in the `checkIfPodNameExistAndIsReused` function. it results in a segmentation violation.

Fix: add a check if Pod is not set, and ignore the Node in that case.