### PR TITLE
Limit PodLister to RedisCluster NS

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -277,12 +277,7 @@ func (c *Controller) syncCluster(rediscluster *rapi.RedisCluster) (forceRequeue 
 			return forceRequeue, err
 		}
 	}
-
-	podselector, err := pod.CreateRedisClusterLabelSelector(rediscluster)
-	if err != nil {
-		return forceRequeue, err
-	}
-	redisClusterPods, err := c.podLister.List(podselector)
+	redisClusterPods, err := c.podControl.GetRedisClusterPods(rediscluster)
 	if err != nil {
 		glog.Errorf("RedisCluster-Operator.sync unable to retrieves pod associated to the RedisCluster: %s/%s", rediscluster.Namespace, rediscluster.Name)
 		return forceRequeue, err

--- a/pkg/controller/pod/control.go
+++ b/pkg/controller/pod/control.go
@@ -55,7 +55,7 @@ func (p *RedisClusterControl) GetRedisClusterPods(redisCluster *rapi.RedisCluste
 	if err != nil {
 		return nil, err
 	}
-	return p.PodLister.List(selector)
+	return p.PodLister.Pods(redisCluster.Namespace).List(selector)
 }
 
 // CreatePod used to create a Pod from the RedisCluster pod template


### PR DESCRIPTION
Fixes: #42

When listening the Pods associated to a redis-cluster the controler
should search only in the redis-cluster namespace.