### PR TITLE
fix: Indent the redis-cluster node selector properly

### DIFF
--- a/chart/redis-cluster/templates/RedisCluster.yml
+++ b/chart/redis-cluster/templates/RedisCluster.yml
@@ -100,6 +100,6 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
 {{- end }}
 {{- if .Values.nodeSelector }}
-          nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 12 }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
 {{- end }}


### PR DESCRIPTION
The `RedisCluster` CRD specifies that the `nodeSelector` needs to be a
child of the `spec` field, but the indentation in the `redis-cluster`
Helm chart makes it a child of one of the containers.  This fix places
it where it should be.